### PR TITLE
[APAM-610] Fix GitHub Actions release workflow for manual versioning

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Work out the new version via Semantic Release
-        if: ${{ inputs.version == '' }}
+        if: ${{ inputs.version == '' || inputs.release_notes_source == 'semantic-release' }}
         uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d #3.4.2
         id: semantic
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,9 @@
 name: Push release to NPM
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
 
 jobs:
   publish-npm:


### PR DESCRIPTION
## Summary
- Use `release: [published]` trigger to trigger the publish workflow
- Fix bug where semantic-release notes would be empty when using manual version input with `semantic-release` notes option

## Problem
When a user provided a manual `version` AND selected `semantic-release` as the notes source, the semantic release step was skipped (since `inputs.version == ''` was false), resulting in empty release notes.

## Solution
Updated the condition to run semantic release when:
- No manual version is provided (original behavior), OR
- `semantic-release` is selected as the notes source

## Test plan
- [ ] Trigger release workflow with no version input and `github` notes - should work as before
- [ ] Trigger release workflow with no version input and `semantic-release` notes - should work as before
- [ ] Trigger release workflow with manual version and `semantic-release` notes - should now generate proper release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)