### PR TITLE
Update iOS SDK to 6.4.0

### DIFF
--- a/airwallex-payment-react-native.podspec
+++ b/airwallex-payment-react-native.podspec
@@ -1,7 +1,7 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-airwallex_version = '~> 6.3.2'
+airwallex_version = '~> 6.4.0'
 
 Pod::Spec.new do |s|
   s.name         = "airwallex-payment-react-native"


### PR DESCRIPTION
## Summary
This PR updates the Airwallex iOS SDK dependency to version `6.4.0`.

### Changes
- Updated iOS SDK dependency from `6.3.2` to `6.4.0`

### Triggered By
Automated update from iOS SDK release `6.4.0`

---
🤖 Generated automatically by repository dispatch event