### PR TITLE
[APAM-659] Fix scene-based key window lookup in iOS getViewController

### DIFF
--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -120,20 +120,16 @@ class AirwallexSdk: RCTEventEmitter {
     }
 
     private func getViewController() -> UIViewController {
-        let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        let keyWindow: UIWindow?
-        if #available(iOS 15.0, *) {
-            keyWindow = windowScene?.keyWindow
-        } else {
-            keyWindow = windowScene?.windows.first(where: { $0.isKeyWindow })
-        }
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
 
-        var presentingViewController = keyWindow?.rootViewController
-        while let presented = presentingViewController?.presentedViewController {
-            presentingViewController = presented
+        var vc = window?.rootViewController
+        while let presented = vc?.presentedViewController {
+            vc = presented
         }
-
-        return presentingViewController ?? UIViewController()
+        return vc ?? UIViewController()
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaced the iOS `getViewController()` key window lookup with a more robust implementation that searches across all connected `UIWindowScene`s
- Removed the iOS 15+ version check (`keyWindow` property) in favor of a unified approach using `isKeyWindow`
- Simplified the presented view controller traversal logic

## Test plan
- [ ] Verify the payment sheet presents correctly on iOS 13+
- [ ] Verify the payment sheet presents correctly on iOS 15+
- [ ] Test with apps using multi-window / `UIScene` lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)