### PR TITLE
[APAM-653] Bind analytics framework info for React Native

### DIFF
--- a/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
@@ -49,6 +49,7 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
     environment: String,
     enableLogging: Boolean,
     saveLogToLocal: Boolean,
+    frameworkVersion: String,
     promise: Promise
   ) {
     try {
@@ -72,7 +73,7 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
               .build()
           )
           AnalyticsLogger.initialize(application)
-          AnalyticsLogger.updateExtraCommonData(mapOf("framework" to "rn"))
+          AnalyticsLogger.updateExtraCommonData(mapOf("framework" to "rn", "frameworkVersion" to frameworkVersion))
           promise.resolve(null)
         }
       } ?: run {

--- a/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
@@ -11,6 +11,7 @@ import com.airwallex.android.core.AirwallexPaymentSession
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexSession
 import com.airwallex.android.core.Environment
+import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.googlepay.GooglePayComponent
 import com.airwallex.android.redirect.RedirectComponent
@@ -70,6 +71,8 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
               )
               .build()
           )
+          AnalyticsLogger.initialize(application)
+          AnalyticsLogger.updateExtraCommonData(mapOf("framework" to "rn"))
           promise.resolve(null)
         }
       } ?: run {

--- a/ios/AirwallexSdk.m
+++ b/ios/AirwallexSdk.m
@@ -7,6 +7,7 @@ RCT_EXTERN_METHOD(
                   initialize:(NSString *)environment
                   enableLogging:(BOOL)enableLogging
                   saveLogToLocal:(BOOL)saveLogToLocal
+                  frameworkVersion:(NSString *)frameworkVersion
                   )
 
 RCT_EXTERN_METHOD(

--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -14,6 +14,7 @@ class AirwallexSdk: RCTEventEmitter {
             Airwallex.setMode(mode)
             AWXAPIClientConfiguration.shared()
         }
+        AnalyticsLogger.shared().bindExtraCommonData(["framework": "rn"])
     }
   
     @objc(presentEntirePaymentFlow:resolver:rejecter:)

--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -8,13 +8,13 @@ class AirwallexSdk: RCTEventEmitter {
     private var paymentConsentID: String?
     private var paymentSessionHandler: PaymentSessionHandler?
     
-    @objc(initialize:enableLogging:saveLogToLocal:)
-    func initialize(environment: String, enableLogging: Bool, saveLogToLocal: Bool) {
+    @objc(initialize:enableLogging:saveLogToLocal:frameworkVersion:)
+    func initialize(environment: String, enableLogging: Bool, saveLogToLocal: Bool, frameworkVersion: String) {
         if let mode = AirwallexSDKMode.from(environment) {
             Airwallex.setMode(mode)
             AWXAPIClientConfiguration.shared()
         }
-        AnalyticsLogger.shared().bindExtraCommonData(["framework": "rn"])
+        AnalyticsLogger.shared().bindExtraCommonData(["framework": "rn", "frameworkVersion": frameworkVersion])
     }
   
     @objc(presentEntirePaymentFlow:resolver:rejecter:)

--- a/src/NativeAirwallexSdk.tsx
+++ b/src/NativeAirwallexSdk.tsx
@@ -7,7 +7,8 @@ type NativeAirwallexSdkType = {
   initialize(
     environment: 'staging' | 'demo' | 'production',
     enableLogging: boolean,
-    saveLogToLocal: boolean
+    saveLogToLocal: boolean,
+    frameworkVersion: string
   ): void;
 
   presentEntirePaymentFlow(session: PaymentSession): Promise<PaymentResult>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,3 +1,4 @@
+import { version } from '../package.json';
 import { transformKeysToSnakeCase } from './helpers';
 import NativeAirwallexSdk from './NativeAirwallexSdk';
 import type { PaymentConsent, PaymentSession } from './types';
@@ -15,7 +16,8 @@ export const initialize = (
   return NativeAirwallexSdk.initialize(
     environment,
     enableLogging,
-    saveLogToLocal
+    saveLogToLocal,
+    version
   );
 };
 


### PR DESCRIPTION

<img width="829" height="236" alt="image" src="https://github.com/user-attachments/assets/7504e8c2-f06b-439d-a864-625087cb8d60" />

## Summary
- Adds `framework: "rn"` to analytics common data on both iOS and Android so analytics events are tagged with the correct integration framework
- **iOS**: Calls `AWXAnalyticsLogger.shared.bindExtraCommonData` in `initialize`
- **Android**: Calls `AnalyticsLogger.initialize` + `updateExtraCommonData` in `initialize`, after `AirwallexStarter.initialize`, to ensure the tracker exists before any payment flow

## Test plan
- [ ] Run iOS example app, trigger a payment flow, verify analytics events contain `framework: "rn"`
- [ ] Run Android example app, trigger a payment flow, verify analytics events contain `framework: "rn"`
- [ ] Verify all payment flow paths (entire, card, Apple Pay/Google Pay, card details, consent) include the framework tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)