### PR TITLE
Update Android SDK to 6.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["AirwallexPaymentReactNative_kotlinVersion"]
-  ext.airwallex_version = "6.6.0"
+  ext.airwallex_version = "6.6.1"
 
   repositories {
     google()


### PR DESCRIPTION
## Summary
This PR updates the Airwallex Android SDK dependency to version `6.6.1`.

### Changes
- Updated Android SDK dependency from `6.6.0` to `6.6.1`

### Triggered By
Automated update from Android SDK release `6.6.1`

---
🤖 Generated automatically by repository dispatch event