### PR TITLE
[APAM-681] Add customerId empty string assertion in native layers

### DIFF
--- a/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
@@ -291,6 +291,8 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
   }
 
   private fun parseSessionFromMap(sessionMap: ReadableMap): AirwallexSession {
+    val customerId = sessionMap.getStringOrNull("customerId")
+    assert(customerId != "") { "customerId must not be an empty string" }
     val type = sessionMap.getStringOrNull("type") ?: error("type is required")
     return when (type) {
       "OneOff" -> {

--- a/ios/AirwallexSdk+Session.swift
+++ b/ios/AirwallexSdk+Session.swift
@@ -9,6 +9,9 @@ import Airwallex
 
 extension AirwallexSdk {
     internal func buildAirwallexSession(from params: NSDictionary) -> AWXSession {
+        if let customerId = params["customerId"] as? String {
+            assert(!customerId.isEmpty, "customerId must not be an empty string")
+        }
         let type = params["type"] as! String
         return switch type {
         case "OneOff":


### PR DESCRIPTION
## Summary
- Add debug-only `assert` in both Kotlin (`parseSessionFromMap`) and Swift (`buildAirwallexSession`) to validate that `customerId` is not an empty string
- Assertions fire during development but are stripped in release builds
- Mirrors the Flutter SDK approach: airwallex/airwallex-payment-flutter#55

## Test plan
- [ ] Verify passing `customerId: ''` triggers assertion failure in debug mode
- [ ] Verify passing `customerId: null` / `undefined` works without error
- [ ] Verify passing a valid `customerId` works without error
- [ ] Verify release builds are unaffected (assertions are stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)