### PR TITLE
[APAM-689] Add preview environment support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,6 +92,10 @@ android {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
   }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
 }
 
 repositories {

--- a/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
@@ -274,6 +274,7 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
       Environment.STAGING.value -> Environment.STAGING
       Environment.DEMO.value -> Environment.DEMO
       Environment.PRODUCTION.value -> Environment.PRODUCTION
+      Environment.PREVIEW.value -> Environment.PREVIEW
       else -> defaultEnvironment
     }
   }

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+ruby '>= 2.6.10'
+
+gem 'cocoapods', '>= 1.13', '< 1.16'
+gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+# Ruby 3.4 removed kconv from stdlib; provided by the nkf gem.
+gem 'nkf'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,0 +1,141 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.8)
+    activesupport (7.0.10)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    claide (1.1.0)
+    cocoapods (1.15.2)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.15.2)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.2)
+      activesupport (>= 5.0, < 8)
+      addressable (~> 2.8)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix (~> 4.0)
+      typhoeus (~> 1.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (2.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.2.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.3.6)
+    drb (2.2.3)
+    escape (0.0.4)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-aarch64-mingw-ucrt)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    json (2.19.4)
+    logger (1.7.0)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    molinillo (0.8.0)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
+    nap (1.1.0)
+    netrc (0.11.0)
+    nkf (0.2.0)
+    prism (1.9.0)
+    public_suffix (4.0.7)
+    rexml (3.4.4)
+    ruby-macho (2.5.1)
+    securerandom (0.4.1)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.27.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  aarch64-mingw-ucrt
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  activesupport (>= 6.1.7.5, < 7.1.0)
+  cocoapods (>= 1.13, < 1.16)
+  nkf
+
+RUBY VERSION
+   ruby 3.4.1p0
+
+BUNDLED WITH
+   2.6.2

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -49,6 +49,11 @@ subprojects {
                 sourceCompatibility = JavaVersion.VERSION_17
                 targetCompatibility = JavaVersion.VERSION_17
             }
+            project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    jvmTarget = "17"
+                }
+            }
         }
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -15,11 +15,14 @@
     "prepare": "node scripts/apply-localizations.js"
   },
   "dependencies": {
+    "@expo/react-native-action-sheet": "^4.1.1",
+    "@react-native-async-storage/async-storage": "^1.24.0",
     "@react-native-picker/picker": "^2.9.0",
     "axios": "^1.7.7",
     "react": "19.0.0",
     "react-native": "0.79.3",
-    "react-native-picker-select": "^9.3.1",
+    "react-native-exit-app": "^2.0.0",
+    "react-native-restart": "^0.0.27",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   ActivityIndicator,
   Platform,
+  SafeAreaView,
 } from 'react-native';
 import {
   initialize,
@@ -17,37 +18,122 @@ import {
   startGooglePay,
   type PaymentSession,
 } from 'airwallex-payment-react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import RNRestart from 'react-native-restart';
+import ExitApp from 'react-native-exit-app';
+import {
+  ActionSheetProvider,
+  useActionSheet,
+} from '@expo/react-native-action-sheet';
 import PaymentService from './api/PaymentService';
 import SessionCreator from './util/SessionCreator';
 import CardCreator from './util/CardCreator';
 import type { PaymentResult } from '../../src/types/PaymentResult';
 import { useEffect, useState } from 'react';
-import RNPickerSelect from 'react-native-picker-select';
+
 import PaymentConsentCreator from './util/PaymentConsentCreator';
 
-type Environment = 'staging' | 'demo';
+type Environment = 'staging' | 'demo' | 'preview';
+type PaymentMode = 'oneOff' | 'recurring' | 'recurringAndPayment';
+
+const ENV_STORAGE_KEY = 'selected_environment';
+const DEFAULT_ENV: Environment = 'demo';
+
+const ENV_OPTIONS: { label: string; value: Environment }[] = [
+  { label: 'Demo', value: 'demo' },
+  { label: 'Staging', value: 'staging' },
+  { label: 'Preview', value: 'preview' },
+];
+
+const PAYMENT_MODE_OPTIONS: { label: string; value: PaymentMode }[] = [
+  { label: 'One Off', value: 'oneOff' },
+  { label: 'Recurring', value: 'recurring' },
+  { label: 'Recurring and Payment', value: 'recurringAndPayment' },
+];
 
 export default function App() {
-  const [loading, setLoading] = useState(false);
-  const [paymentMode, setPaymentMode] = useState('oneOff');
-  const [environment, setEnvironment] = useState<Environment>('demo');
-  const [paymentService, setPaymentService] = useState(
-    new PaymentService(environment, '', '')
+  return (
+    <ActionSheetProvider>
+      <Main />
+    </ActionSheetProvider>
   );
+}
+
+function Main() {
+  const { showActionSheetWithOptions } = useActionSheet();
+  const [loading, setLoading] = useState(false);
+  const [paymentMode, setPaymentMode] = useState<PaymentMode>('oneOff');
+  const [environment, setEnvironment] = useState<Environment>(DEFAULT_ENV);
+  const [paymentService, setPaymentService] = useState(
+    new PaymentService(DEFAULT_ENV, '', '')
+  );
+  const [sdkReady, setSdkReady] = useState(false);
 
   useEffect(() => {
-    setPaymentService(new PaymentService(environment, '', ''));
-    const initializeSdk = (env: Environment) => {
-      try {
-        initialize(env, true, false);
-        console.log('SDK initialized successfully');
-      } catch (error) {
-        console.error('Error initializing SDK:', error);
-        Alert.alert('Error', 'Failed to initialize SDK.');
+    AsyncStorage.getItem(ENV_STORAGE_KEY).then((stored) => {
+      const env = ENV_OPTIONS.some((o) => o.value === stored)
+        ? (stored as Environment)
+        : DEFAULT_ENV;
+      setEnvironment(env);
+      setPaymentService(new PaymentService(env, '', ''));
+      initialize(env, true, false);
+      console.log('SDK initialized with environment:', env);
+      setSdkReady(true);
+    });
+  }, []);
+
+  const handleEnvironmentChange = async (newEnv: Environment) => {
+    if (newEnv === environment) return;
+    await AsyncStorage.setItem(ENV_STORAGE_KEY, newEnv);
+    Alert.alert(
+      'Restart Required',
+      'The app needs to restart for the new environment to take effect.',
+      [
+        {
+          text: 'OK',
+          onPress: () =>
+            Platform.OS === 'ios' ? ExitApp.exitApp() : RNRestart.restart(),
+        },
+      ],
+      { cancelable: false }
+    );
+  };
+
+  const showEnvironmentSheet = () => {
+    const labels = [...ENV_OPTIONS.map((o) => o.label), 'Cancel'];
+    showActionSheetWithOptions(
+      {
+        title: 'Select Environment',
+        options: labels,
+        cancelButtonIndex: labels.length - 1,
+      },
+      (selectedIndex) => {
+        if (selectedIndex == null || selectedIndex === labels.length - 1)
+          return;
+        handleEnvironmentChange(ENV_OPTIONS[selectedIndex]!.value);
       }
-    };
-    initializeSdk(environment);
-  }, [environment]);
+    );
+  };
+
+  const showPaymentModeSheet = () => {
+    const labels = [...PAYMENT_MODE_OPTIONS.map((o) => o.label), 'Cancel'];
+    showActionSheetWithOptions(
+      {
+        title: 'Payment Mode',
+        options: labels,
+        cancelButtonIndex: labels.length - 1,
+      },
+      (selectedIndex) => {
+        if (selectedIndex == null || selectedIndex === labels.length - 1)
+          return;
+        setPaymentMode(PAYMENT_MODE_OPTIONS[selectedIndex]!.value);
+      }
+    );
+  };
+
+  const paymentModeLabel =
+    PAYMENT_MODE_OPTIONS.find((o) => o.value === paymentMode)?.label ??
+    'Payment Mode';
 
   async function fetchSession(requireCustomerId = false) {
     setLoading(true);
@@ -168,23 +254,24 @@ export default function App() {
     }
   };
 
+  if (!sdkReady) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color="#007BFF" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <View style={styles.topBar}>
-        <RNPickerSelect
-          onValueChange={setEnvironment}
-          items={[
-            { label: 'Demo', value: 'demo' },
-            { label: 'Staging', value: 'staging' },
-          ]}
-          value={environment}
-          placeholder={{}}
-          style={{
-            inputIOS: styles.environmentPicker,
-            inputAndroid: styles.environmentPicker,
-          }}
-        />
-      </View>
+      <SafeAreaView style={styles.topBar}>
+        <TouchableOpacity
+          style={styles.environmentPicker}
+          onPress={showEnvironmentSheet}
+        >
+          <Text style={styles.environmentPickerText}>{environment}</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
       {loading && (
         <ActivityIndicator
           size="large"
@@ -192,24 +279,9 @@ export default function App() {
           style={styles.loading}
         />
       )}
-      <RNPickerSelect
-        onValueChange={(value) => setPaymentMode(value)}
-        items={[
-          { label: 'One Off', value: 'oneOff' },
-          { label: 'Recurring', value: 'recurring' },
-          { label: 'Recurring and Payment', value: 'recurringAndPayment' },
-        ]}
-        value={paymentMode}
-        placeholder={{
-          label: 'Payment Mode',
-          value: null,
-          color: '#007BFF',
-        }}
-        style={{
-          inputIOS: styles.picker,
-          inputAndroid: styles.picker,
-        }}
-      />
+      <TouchableOpacity style={styles.picker} onPress={showPaymentModeSheet}>
+        <Text style={styles.pickerText}>{paymentModeLabel}</Text>
+      </TouchableOpacity>
 
       <TouchableOpacity
         style={styles.button}
@@ -280,15 +352,18 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   environmentPicker: {
-    fontSize: 14,
     paddingVertical: 8,
     paddingHorizontal: 10,
     borderWidth: 1,
     borderColor: 'gray',
     borderRadius: 4,
     backgroundColor: 'white',
+    width: 100,
+    alignItems: 'center',
+  },
+  environmentPickerText: {
+    fontSize: 14,
     color: 'black',
-    width: 150,
   },
   button: {
     marginVertical: 10,
@@ -309,15 +384,18 @@ const styles = StyleSheet.create({
     transform: [{ translateX: -25 }, { translateY: -25 }],
   },
   picker: {
-    fontSize: 16,
     paddingVertical: 12,
     paddingHorizontal: 10,
     borderWidth: 1,
     borderColor: 'gray',
     borderRadius: 4,
-    color: 'black',
     width: '80%',
     alignSelf: 'center',
     marginBottom: 20,
+    alignItems: 'center',
+  },
+  pickerText: {
+    fontSize: 16,
+    color: 'black',
   },
 });

--- a/example/src/api/PaymentService.ts
+++ b/example/src/api/PaymentService.ts
@@ -12,7 +12,7 @@ class PaymentService {
   private clientId: string;
 
   constructor(
-    environment: 'staging' | 'demo' | 'production' = 'demo',
+    environment: 'staging' | 'demo' | 'production' | 'preview' = 'demo',
     apiKey: string,
     clientId: string
   ) {
@@ -121,13 +121,15 @@ class PaymentService {
   }
 
   getBaseUrlForEnvironment(
-    environment: 'staging' | 'demo' | 'production'
+    environment: 'staging' | 'demo' | 'production' | 'preview'
   ): string {
     switch (environment) {
       case 'demo':
         return 'https://demo-pacheckoutdemo.airwallex.com';
       case 'staging':
         return 'https://staging-pacheckoutdemo.airwallex.com';
+      case 'preview':
+        return 'https://pacheckoutdemo.sandbox.airwallex.com';
       default:
         return '';
     }

--- a/example/src/util/CardCreator.ts
+++ b/example/src/util/CardCreator.ts
@@ -9,7 +9,7 @@ class CardCreator {
       cvc: '737',
     };
 
-    if (environment === 'demo') {
+    if (environment === 'demo' || environment === 'preview') {
       return {
         number: '4012000300001003',
         ...card,

--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -169,6 +169,8 @@ private extension AirwallexSDKMode {
             .demoMode
         case "production":
             .productionMode
+        case "preview":
+            .previewMode
         default:
             nil
         }

--- a/src/NativeAirwallexSdk.tsx
+++ b/src/NativeAirwallexSdk.tsx
@@ -5,7 +5,7 @@ import type { Card } from './types/Card';
 
 type NativeAirwallexSdkType = {
   initialize(
-    environment: 'staging' | 'demo' | 'production',
+    environment: 'staging' | 'demo' | 'production' | 'preview',
     enableLogging: boolean,
     saveLogToLocal: boolean
   ): void;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -5,7 +5,7 @@ import type { Card } from './types/Card';
 import type { PaymentResult } from './types/PaymentResult';
 
 export const initialize = (
-  environment: 'staging' | 'demo' | 'production' = 'production',
+  environment: 'staging' | 'demo' | 'production' | 'preview' = 'production',
   enableLogging: boolean = true,
   saveLogToLocal: boolean = false
 ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1768,6 +1768,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/react-native-action-sheet@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@expo/react-native-action-sheet@npm:4.1.1"
+  dependencies:
+    "@types/hoist-non-react-statics": ^3.3.1
+    hoist-non-react-statics: ^3.3.0
+  peerDependencies:
+    react: ">=18.0.0"
+  checksum: eea30883f4ef3b8793630080191d2e47a07747ec316c00821203daa0d2b4bedf983b2a9171e7709ed30b8d5f149efd6e98f944c3c4c7eab936cfd0af592b3642
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -2423,6 +2435,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-async-storage/async-storage@npm:^1.24.0":
+  version: 1.24.0
+  resolution: "@react-native-async-storage/async-storage@npm:1.24.0"
+  dependencies:
+    merge-options: ^3.0.4
+  peerDependencies:
+    react-native: ^0.0.0-0 || >=0.60 <1.0
+  checksum: 7e56a2e97f48332f57c56ebf473b763c7ca2b1ef82f4b5f8e1c73350231ec91b8eafc4e4d1f972c4c1005da0d304816fa725dc6f07a8a7543e90f8bd16c22ab4
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-clean@npm:18.0.0":
   version: 18.0.0
   resolution: "@react-native-community/cli-clean@npm:18.0.0"
@@ -3059,6 +3082,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.7
+  resolution: "@types/hoist-non-react-statics@npm:3.3.7"
+  dependencies:
+    hoist-non-react-statics: ^3.3.0
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 13f610572c073970b3f43cc446396974fed786fee6eac2d6fd4b0ca5c985f13e79d4a0de58af4e5b4c68470d808567c3a14108d98edb7d526d4d46c8ec851ed1
+  languageName: node
+  linkType: hard
+
 "@types/http-cache-semantics@npm:^4.0.2":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
@@ -3427,6 +3461,8 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
+    "@expo/react-native-action-sheet": ^4.1.1
+    "@react-native-async-storage/async-storage": ^1.24.0
     "@react-native-community/cli": latest
     "@react-native-picker/picker": ^2.9.0
     "@react-native/babel-preset": 0.79.3
@@ -3437,7 +3473,8 @@ __metadata:
     react: 19.0.0
     react-native: 0.79.3
     react-native-builder-bob: ^0.30.2
-    react-native-picker-select: ^9.3.1
+    react-native-exit-app: ^2.0.0
+    react-native-restart: ^0.0.27
     react-native-test-app: ^4.4.0
     reflect-metadata: ^0.2.2
   languageName: unknown
@@ -7137,6 +7174,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -7765,6 +7811,13 @@ __metadata:
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
   checksum: 0ee04807797aad50859652a7467481816cbb57e5cc97d813a7dcd8915da8195dc68c436010bf39d195226cde6a2d352f4b815f16f26b7bf486a5754290629931
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
   languageName: node
   linkType: hard
 
@@ -8897,13 +8950,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.isequal@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
-  languageName: node
-  linkType: hard
-
 "lodash.isfunction@npm:^3.0.9":
   version: 3.0.9
   resolution: "lodash.isfunction@npm:3.0.9"
@@ -8915,13 +8961,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.ismatch@npm:4.4.0"
   checksum: a393917578842705c7fc1a30fb80613d1ac42d20b67eb26a2a6004d6d61ee90b419f9eb320508ddcd608e328d91eeaa2651411727eaa9a12534ed6ccb02fc705
-  languageName: node
-  linkType: hard
-
-"lodash.isobject@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "lodash.isobject@npm:3.0.2"
-  checksum: 6c1667cbc4494d0a13a3617a4b23278d6d02dac520311f2bbb43f16f2cf71d2e6eb9dec8057315b77459df4890c756a256a087d3f4baa44a79ab5d6c968b060e
   languageName: node
   linkType: hard
 
@@ -9221,6 +9260,15 @@ __metadata:
     type-fest: ^0.18.0
     yargs-parser: ^20.2.3
   checksum: bc23bf1b4423ef6a821dff9734406bce4b91ea257e7f10a8b7f896f45b59649f07adc0926e2917eacd8cf1df9e4cd89c77623cf63dfd0f8bf54de07a32ee5a85
+  languageName: node
+  linkType: hard
+
+"merge-options@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "merge-options@npm:3.0.4"
+  dependencies:
+    is-plain-obj: ^2.1.0
+  checksum: d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
   languageName: node
   linkType: hard
 
@@ -11072,7 +11120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -11125,15 +11173,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-picker-select@npm:^9.3.1":
-  version: 9.3.1
-  resolution: "react-native-picker-select@npm:9.3.1"
-  dependencies:
-    lodash.isequal: ^4.5.0
-    lodash.isobject: ^3.0.2
+"react-native-exit-app@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-native-exit-app@npm:2.0.0"
+  checksum: d455ddd3a688625ec0521c0260a709e9e1dedaa7ef5bdebc76b87017056950f79366e2b4686f864c8127555a5359b6bfc5b2636477f99f86ad1920ea1d87360e
+  languageName: node
+  linkType: hard
+
+"react-native-restart@npm:^0.0.27":
+  version: 0.0.27
+  resolution: "react-native-restart@npm:0.0.27"
   peerDependencies:
-    "@react-native-picker/picker": ^2.4.0
-  checksum: ba03c79bff736f225f6cf06a971a5058739ef27c26d2f66edf31e80250fc40be29085d4b15a35339c31b4d4830d362594f8d5933a25a0f2f1f9d702189e2d611
+    react: "*"
+    react-native: "*"
+  checksum: 49cfaa954f12c37c6e34988cb47bf0626f4a2cd68ecc15be3d8d6acc7a5ca3032729545ddb66b6d3a5c30dfe626e46010e3e2148e709487354907997fde64255
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Summary
- Adds `preview` environment value across the SDK (Android Kotlin, iOS Swift, JS types) and example app
- Example app: persist selected env via AsyncStorage (with stored-value validation), restart on env change, and replace `Alert`/`RNPickerSelect` pickers with `@expo/react-native-action-sheet`
- Build/dev-env fixes: align Kotlin `jvmTarget` to 17 so JDK 21 hosts build; add `example/Gemfile` (with `nkf` for Ruby 3.4's `kconv` removal) so RN CLI's `bundle exec pod install` works during `yarn ios`

| Android | iOS |
|--------|--------|
| <img width="300" height="700" alt="Screenshot_20260427_182546" src="https://github.com/user-attachments/assets/d79886fa-4a1f-4b1d-8d76-28476102f4fc" /> | <img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-27 at 18 25 29" src="https://github.com/user-attachments/assets/9a9462de-3842-4290-8833-ef637360f376" /> |
| <img width="300" height="700" alt="Screenshot_20260427_182602" src="https://github.com/user-attachments/assets/bd782673-10ae-4997-bb29-da386d621da0" /> | <img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-27 at 18 25 36" src="https://github.com/user-attachments/assets/98925f90-1be6-48d3-82d1-0e20979bf296" /> | 

## Test plan
- [x] Android: `yarn android` builds on JDK 21; env switcher (Demo / Staging / Preview) persists across restarts; payment flows succeed for each env
- [x] iOS: `yarn ios` runs `bundle exec pod install` cleanly on Ruby 3.4; env switcher persists across restarts (manual reopen after `ExitApp.exitApp()`)
- [x] Preview env: `https://pacheckoutdemo.sandbox.airwallex.com` reachable; demo test card `4012000300001003` accepted
- [ ] No regression for existing `demo` / `staging` flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

