### PR TITLE
[APAM-740] Add layout configuration for entire payment flow

### DIFF
--- a/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/AirwallexPaymentReactNativeModule.kt
@@ -21,6 +21,7 @@ import com.airwallexpaymentreactnative.util.AirwallexRecurringSessionConverter
 import com.airwallexpaymentreactnative.util.AirwallexRecurringWithIntentSessionConverter
 import com.airwallexpaymentreactnative.util.PaymentCardConverter
 import com.airwallexpaymentreactnative.util.PaymentConsentConverter
+import com.airwallexpaymentreactnative.util.PaymentSheetConfigurationConverter
 import com.airwallexpaymentreactnative.util.getStringOrNull
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -85,13 +86,19 @@ class AirwallexPaymentReactNativeModule(private val reactContext: ReactApplicati
   }
 
   @ReactMethod
-  fun presentEntirePaymentFlow(session: ReadableMap, promise: Promise) {
+  fun presentEntirePaymentFlow(
+    session: ReadableMap,
+    configuration: ReadableMap?,
+    promise: Promise
+  ) {
     val currentActivity = requireComponentActivity(promise) ?: return
     try {
       val paymentSession = parseSessionFromMap(session)
+      val sheetConfiguration = PaymentSheetConfigurationConverter.fromReadableMap(configuration)
       AirwallexStarter.presentEntirePaymentFlow(
         currentActivity,
         paymentSession,
+        configuration = sheetConfiguration,
         paymentResultListener = object : Airwallex.PaymentResultListener {
           override fun onCompleted(status: AirwallexPaymentStatus) {
             when (status) {

--- a/android/src/main/java/com/airwallexpaymentreactnative/util/PaymentSheetConfigurationConverter.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/util/PaymentSheetConfigurationConverter.kt
@@ -1,0 +1,15 @@
+package com.airwallexpaymentreactnative.util
+
+import com.airwallex.android.core.PaymentMethodsLayoutType
+import com.airwallex.android.view.composables.PaymentElementConfiguration
+import com.facebook.react.bridge.ReadableMap
+
+object PaymentSheetConfigurationConverter {
+  fun fromReadableMap(map: ReadableMap?): PaymentElementConfiguration.PaymentSheet {
+    val layout = when (map?.getStringOrNull("layout")?.lowercase()) {
+      "accordion" -> PaymentMethodsLayoutType.ACCORDION
+      else -> PaymentMethodsLayoutType.TAB
+    }
+    return PaymentElementConfiguration.PaymentSheet(layout = layout)
+  }
+}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -6,4 +6,13 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 
 workspace 'AirwallexPaymentReactNativeExample.xcworkspace'
 
-use_test_app!
+use_test_app!(
+  :post_install => ->(installer) {
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'fmt'
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'gnu++17'
+      end
+    end
+  }
+)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -289,7 +289,19 @@ function Main() {
           handlePaymentFlowPress(presentEntirePaymentFlow);
         }}
       >
-        <Text style={styles.buttonText}>PresentEntirePaymentFlow</Text>
+        <Text style={styles.buttonText}>PresentEntirePaymentFlow (tab)</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => {
+          handlePaymentFlowPress((session) =>
+            presentEntirePaymentFlow(session, { layout: 'accordion' })
+          );
+        }}
+      >
+        <Text style={styles.buttonText}>
+          PresentEntirePaymentFlow (accordion)
+        </Text>
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.button}

--- a/ios/AWXUIContextConfiguration+Extensions.swift
+++ b/ios/AWXUIContextConfiguration+Extensions.swift
@@ -1,0 +1,17 @@
+//
+//  AWXUIContextConfiguration+Extensions.swift
+//  airwallex-payment-react-native
+//
+
+import Airwallex
+
+extension AWXUIContext.Configuration {
+    convenience init(params: NSDictionary?) {
+        self.init()
+        if let layoutString = params?["layout"] as? String, layoutString.lowercased() == "accordion" {
+            layout = .accordion
+        } else {
+            layout = .tab
+        }
+    }
+}

--- a/ios/AirwallexSdk.m
+++ b/ios/AirwallexSdk.m
@@ -12,6 +12,7 @@ RCT_EXTERN_METHOD(
 
 RCT_EXTERN_METHOD(
                   presentEntirePaymentFlow:(NSDictionary *)session
+                  configuration:(NSDictionary *)configuration
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   )

--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -17,21 +17,23 @@ class AirwallexSdk: RCTEventEmitter {
         AnalyticsLogger.shared().bindExtraCommonData(["framework": "rn", "frameworkVersion": frameworkVersion])
     }
   
-    @objc(presentEntirePaymentFlow:resolver:rejecter:)
-    func presentEntirePaymentFlow(session: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc(presentEntirePaymentFlow:configuration:resolver:rejecter:)
+    func presentEntirePaymentFlow(session: NSDictionary, configuration: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         self.resolve = resolve
         self.reject = reject
-        
+
         AWXAPIClientConfiguration.shared().clientSecret = session["clientSecret"] as? String
-        
+
         let session = buildAirwallexSession(from: session)
-        
+        let sheetConfiguration = AWXUIContext.Configuration(params: configuration)
+        sheetConfiguration.launchStyle = .present
+
         DispatchQueue.main.async {
             AWXUIContext.launchPayment(
                 from: self.getViewController(),
                 session: session,
                 paymentResultDelegate: self,
-                launchStyle: .present
+                configuration: sheetConfiguration
             )
         }
     }

--- a/src/NativeAirwallexSdk.tsx
+++ b/src/NativeAirwallexSdk.tsx
@@ -1,5 +1,9 @@
 import { NativeModules } from 'react-native';
-import type { PaymentConsent, PaymentSession } from './types';
+import type {
+  PaymentConsent,
+  PaymentSession,
+  PaymentSheetConfiguration,
+} from './types';
 import type { PaymentResult } from './types/PaymentResult';
 import type { Card } from './types/Card';
 
@@ -11,7 +15,10 @@ type NativeAirwallexSdkType = {
     frameworkVersion: string
   ): void;
 
-  presentEntirePaymentFlow(session: PaymentSession): Promise<PaymentResult>;
+  presentEntirePaymentFlow(
+    session: PaymentSession,
+    configuration?: PaymentSheetConfiguration
+  ): Promise<PaymentResult>;
 
   presentCardPaymentFlow(session: PaymentSession): Promise<PaymentResult>;
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,7 +1,11 @@
 import { version } from './version';
 import { transformKeysToSnakeCase } from './helpers';
 import NativeAirwallexSdk from './NativeAirwallexSdk';
-import type { PaymentConsent, PaymentSession } from './types';
+import type {
+  PaymentConsent,
+  PaymentSession,
+  PaymentSheetConfiguration,
+} from './types';
 import type { Card } from './types/Card';
 import type { PaymentResult } from './types/PaymentResult';
 
@@ -22,9 +26,10 @@ export const initialize = (
 };
 
 export const presentEntirePaymentFlow = async (
-  session: PaymentSession
+  session: PaymentSession,
+  configuration?: PaymentSheetConfiguration
 ): Promise<PaymentResult> => {
-  return NativeAirwallexSdk.presentEntirePaymentFlow(session);
+  return NativeAirwallexSdk.presentEntirePaymentFlow(session, configuration);
 };
 
 export const presentCardPaymentFlow = async (

--- a/src/types/PaymentSheetConfiguration.ts
+++ b/src/types/PaymentSheetConfiguration.ts
@@ -1,0 +1,5 @@
+export type PaymentLayout = 'tab' | 'accordion';
+
+export interface PaymentSheetConfiguration {
+  layout: PaymentLayout;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './PaymentConsent';
 export * from './Shipping';
 export * from './ApplePayOptions';
 export * from './GooglePayOptions';
+export * from './PaymentSheetConfiguration';


### PR DESCRIPTION
## Summary
- Adds optional `configuration` argument to `presentEntirePaymentFlow` exposing the SDKs' tab/accordion layout choice (`{ layout: 'tab' | 'accordion' }`)
- Mirrors the native configuration-object APIs (`AWXUIContext.Configuration` on iOS, `PaymentElementConfiguration.PaymentSheet` on Android); omitting the argument preserves the existing default (tab)
- Updates the example app with a second button demonstrating the accordion layout

iOS:

https://github.com/user-attachments/assets/89785446-5dbd-4975-9068-1c5fccf847f9

Android:

[Screen_recording_20260522_150759.webm](https://github.com/user-attachments/assets/b77c6236-0c8d-4a8b-a8fd-e49ee24a2d42)


## Test plan
- [x] `yarn typecheck` passes
- [x] iOS example: tap **PresentEntirePaymentFlow (tab)** — sheet renders tab layout (unchanged behaviour)
- [x] iOS example: tap **PresentEntirePaymentFlow (accordion)** — sheet renders accordion layout
- [x] Android example: same two checks
- [x] Regression: `PresentCardPaymentFlow` still works on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)