### PR TITLE
[APAM-751] Pass shipping to Android session builder for billing pre-fill

### DIFF
--- a/android/src/main/java/com/airwallexpaymentreactnative/util/AirwallexPaymentSessionConverter.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/util/AirwallexPaymentSessionConverter.kt
@@ -59,6 +59,7 @@ object AirwallexPaymentSessionConverter {
       .setAutoCapture(autoCapture)
       .setHidePaymentConsents(hidePaymentConsents)
       .setPaymentMethods(paymentMethods)
+      .setShipping(shipping)
       .build()
   }
 

--- a/android/src/main/java/com/airwallexpaymentreactnative/util/AirwallexRecurringWithIntentSessionConverter.kt
+++ b/android/src/main/java/com/airwallexpaymentreactnative/util/AirwallexRecurringWithIntentSessionConverter.kt
@@ -69,6 +69,7 @@ object AirwallexRecurringWithIntentSessionConverter {
       .setRequireEmail(isEmailRequired)
       .setReturnUrl(returnUrl)
       .setAutoCapture(autoCapture)
+      .setShipping(shipping)
 
     merchantTriggerReason?.let {
       sessionBuilder.setMerchantTriggerReason(merchantTriggerReason)


### PR DESCRIPTION
## Summary
- Mirrors the Flutter fix in [airwallex-payment-flutter#68](https://github.com/airwallex/airwallex-payment-flutter/pull/68) for React Native
- On Android, `AirwallexPaymentSession` and `AirwallexRecurringWithIntentSession` were placing `shipping` only into `PaymentIntent.order` (as a `PurchaseOrder`) but never calling `.setShipping()` on the session builder
- The Android SDK uses the session-level `shipping` field to pre-fill billing form fields; without it, the form stayed empty even when shipping data was provided
- iOS already maps `shipping` → `session.billing` for pre-fill

<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/31a0aa8b-421a-4ffe-adcd-be2cfeff4b2e" />

## Test plan
- [x] Run the example app on Android, open a card payment flow via `OneOffSession` with shipping data — confirm billing fields (name, email, phone, address) are pre-filled
- [x] Repeat for `RecurringWithIntentSession`
- [x] Confirm `RecurringSession` (unchanged) still pre-fills correctly
- [x] Confirm iOS behaviour is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)