### PR TITLE
[APAM-784] Documents for public API

### DIFF
--- a/ios/AirwallexSdk.swift
+++ b/ios/AirwallexSdk.swift
@@ -12,6 +12,11 @@ class AirwallexSdk: RCTEventEmitter {
     func initialize(environment: String, enableLogging: Bool, saveLogToLocal: Bool, frameworkVersion: String) {
         if let mode = AirwallexSDKMode.from(environment) {
             Airwallex.setMode(mode)
+            if saveLogToLocal {
+                Airwallex.enableLocalLogFile()
+            } else {
+                Airwallex.disableLocalLogFile()
+            }
             AWXAPIClientConfiguration.shared()
         }
         AnalyticsLogger.shared().bindExtraCommonData(["framework": "rn", "frameworkVersion": frameworkVersion])

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -9,6 +9,13 @@ import type {
 import type { Card } from './types/Card';
 import type { PaymentResult } from './types/PaymentResult';
 
+/**
+ * Initializes the Airwallex SDK. Call this once at app startup before invoking any other payment method.
+ *
+ * @param environment - The Airwallex environment to connect to. Defaults to `'production'`.
+ * @param enableLogging - When `true`, the SDK emits logs to the console. Android only. Defaults to `true`.
+ * @param saveLogToLocal - When `true`, logs are also persisted to a local file for debugging. Defaults to `false`.
+ */
 export const initialize = (
   environment: 'staging' | 'demo' | 'production' | 'preview' = 'production',
   enableLogging: boolean = true,
@@ -25,6 +32,14 @@ export const initialize = (
   );
 };
 
+/**
+ * Presents the full Airwallex payment sheet, letting the customer pick any supported payment method
+ * (cards, wallets, redirect methods) and complete the payment.
+ *
+ * @param session - The payment session describing the intent, amount, currency, and customer.
+ * @param configuration - Optional UI configuration for the payment sheet (e.g. layout).
+ * @returns The result of the payment attempt.
+ */
 export const presentEntirePaymentFlow = async (
   session: PaymentSession,
   configuration?: PaymentSheetConfiguration
@@ -32,24 +47,52 @@ export const presentEntirePaymentFlow = async (
   return NativeAirwallexSdk.presentEntirePaymentFlow(session, configuration);
 };
 
+/**
+ * Presents the card-only payment sheet. Use this when the merchant wants to restrict checkout
+ * to card payments and skip the payment-method selection screen.
+ *
+ * @param session - The payment session describing the intent, amount, currency, and customer.
+ * @returns The result of the payment attempt.
+ */
 export const presentCardPaymentFlow = async (
   session: PaymentSession
 ): Promise<PaymentResult> => {
   return NativeAirwallexSdk.presentCardPaymentFlow(session);
 };
 
+/**
+ * Starts a Google Pay payment flow. Android only.
+ *
+ * @param session - The payment session. Must include `googlePayOptions` for the merchant configuration.
+ * @returns The result of the payment attempt.
+ */
 export const startGooglePay = async (
   session: PaymentSession
 ): Promise<PaymentResult> => {
   return NativeAirwallexSdk.startGooglePay(session);
 };
 
+/**
+ * Starts an Apple Pay payment flow. iOS only.
+ *
+ * @param session - The payment session. Must include `applePayOptions` for the merchant configuration.
+ * @returns The result of the payment attempt.
+ */
 export const startApplePay = async (
   session: PaymentSession
 ): Promise<PaymentResult> => {
   return NativeAirwallexSdk.startApplePay(session);
 };
 
+/**
+ * Pays with raw card details collected by the merchant's own UI. The merchant is responsible
+ * for PCI compliance when using this method.
+ *
+ * @param session - The payment session describing the intent, amount, currency, and customer.
+ * @param card - The card details to charge.
+ * @param saveCard - When `true`, the card is saved as a payment consent for future use.
+ * @returns The result of the payment attempt.
+ */
 export const payWithCardDetails = async (
   session: PaymentSession,
   card: Card,
@@ -62,6 +105,13 @@ export const payWithCardDetails = async (
   );
 };
 
+/**
+ * Pays using an existing payment consent (a previously saved card).
+ *
+ * @param session - The payment session describing the intent, amount, currency, and customer.
+ * @param consent - The payment consent to charge.
+ * @returns The result of the payment attempt.
+ */
 export const payWithConsent = async (
   session: PaymentSession,
   consent: PaymentConsent

--- a/src/types/ApplePayOptions.ts
+++ b/src/types/ApplePayOptions.ts
@@ -1,3 +1,9 @@
+/**
+ * Apple Pay configuration. Required on a `PaymentSession` when invoking
+ * {@link startApplePay}, or when offering Apple Pay through {@link presentEntirePaymentFlow} on iOS.
+ *
+ * `merchantIdentifier` must match the Apple Pay merchant ID configured in the app's entitlements.
+ */
 export interface ApplePayOptions {
   merchantIdentifier: string;
   supportedNetworks?: ApplePaySupportedNetwork[];
@@ -8,6 +14,9 @@ export interface ApplePayOptions {
   totalPriceLabel?: string;
 }
 
+/**
+ * Card networks the merchant is willing to accept through Apple Pay.
+ */
 export enum ApplePaySupportedNetwork {
   Visa = 'visa',
   MasterCard = 'masterCard',
@@ -18,6 +27,9 @@ export enum ApplePaySupportedNetwork {
   Mastreo = 'maestro',
 }
 
+/**
+ * Payment-processing capabilities the merchant supports. `Supports3DS` is required by Apple Pay.
+ */
 export enum ApplePayMerchantCapability {
   Supports3DS = 'supports3DS',
   SupportsCredit = 'supportsCredit',
@@ -25,6 +37,9 @@ export enum ApplePayMerchantCapability {
   SupportsEMV = 'supportsEMV',
 }
 
+/**
+ * Contact fields the merchant requires from the customer during Apple Pay checkout.
+ */
 export enum ContactField {
   EmailAddress = 'emailAddress',
   Name = 'name',
@@ -33,12 +48,20 @@ export enum ContactField {
   PostalAddress = 'postalAddress',
 }
 
+/**
+ * An additional line item displayed in the Apple Pay summary
+ * (e.g. tax, shipping, discount) on top of the session amount.
+ */
 export interface CartSummaryItem {
   label: string;
   amount: number;
   type?: CartSummaryItemType;
 }
 
+/**
+ * Whether a {@link CartSummaryItem} amount is final or still pending
+ * (e.g. shipping not yet calculated).
+ */
 export enum CartSummaryItemType {
   Final = 'final',
   Pending = 'pending',

--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -1,3 +1,11 @@
+/**
+ * Card details. When used as input to {@link payWithCardDetails}, the merchant
+ * supplies `number`, `expiryMonth`, `expiryYear`, `cvc`, and optionally `name`.
+ *
+ * The remaining fields (`bin`, `last4`, `brand`, `fingerprint`, `cvcCheck`,
+ * `avsCheck`, etc.) are populated by Airwallex when a Card is returned as part of
+ * a saved payment method on a {@link PaymentConsent}.
+ */
 export interface Card {
   cvc?: string;
   expiryMonth?: string;

--- a/src/types/GooglePayOptions.ts
+++ b/src/types/GooglePayOptions.ts
@@ -1,18 +1,34 @@
+/**
+ * How much of the billing address Google Pay should return.
+ *
+ * - `MIN` — postal code and country only (sufficient for most card validation).
+ * - `FULL` — full address.
+ */
 export enum Format {
   MIN = 'min',
   FULL = 'full',
 }
 
+/**
+ * Controls how the customer's billing address is collected via Google Pay.
+ */
 export interface BillingAddressParameters {
   format?: Format;
   phoneNumberRequired?: boolean;
 }
 
+/**
+ * Controls how the customer's shipping address is collected via Google Pay.
+ */
 export interface ShippingAddressParameters {
   allowedCountryCodes?: string[];
   phoneNumberRequired?: boolean;
 }
 
+/**
+ * Google Pay configuration. Required on a `PaymentSession` when invoking
+ * {@link startGooglePay}, or when offering Google Pay through {@link presentEntirePaymentFlow} on Android.
+ */
 export interface GooglePayOptions {
   allowedCardAuthMethods?: string[];
   merchantName?: string;
@@ -31,6 +47,10 @@ export interface GooglePayOptions {
   skipReadinessCheck?: boolean;
 }
 
+/**
+ * The set of card networks Airwallex supports through Google Pay. Useful as a default value
+ * for `GooglePayOptions.allowedCardNetworks` when the merchant has no preference.
+ */
 export function googlePaySupportedNetworks(): string[] {
   return [
     'AMEX',

--- a/src/types/PaymentConsent.ts
+++ b/src/types/PaymentConsent.ts
@@ -1,16 +1,31 @@
 import type { Card } from './Card';
 import type { Shipping } from './Shipping';
 
+/**
+ * Who initiates the next charge against a saved payment consent.
+ */
 export enum NextTriggeredBy {
   Merchant = 'merchant',
   Customer = 'customer',
 }
 
+/**
+ * Why the merchant is triggering a charge against a saved payment consent.
+ * Only meaningful when {@link NextTriggeredBy} is `Merchant`.
+ *
+ * - `Scheduled` — fixed-interval billing the customer has agreed to (e.g. monthly subscription).
+ * - `Unscheduled` — merchant-initiated charge at an unpredictable time (e.g. account top-up, usage overage).
+ */
 export enum MerchantTriggerReason {
   Unscheduled = 'unscheduled',
   Scheduled = 'scheduled',
 }
 
+/**
+ * A reusable payment authorization tied to a customer and a payment method.
+ * Created during a `RecurringSession` / `RecurringWithIntentSession` flow,
+ * and later passed to {@link payWithConsent} to charge without re-prompting the customer.
+ */
 export interface PaymentConsent {
   id?: string;
   requestId?: string;
@@ -24,6 +39,10 @@ export interface PaymentConsent {
   clientSecret?: string;
 }
 
+/**
+ * The payment instrument attached to a {@link PaymentConsent} — typically a saved card,
+ * along with its billing details.
+ */
 export interface PaymentMethod {
   id?: string;
   type?: string;

--- a/src/types/PaymentResult.ts
+++ b/src/types/PaymentResult.ts
@@ -1,16 +1,33 @@
+/**
+ * The payment completed successfully. If a payment consent was created during the
+ * flow, its id is returned in `paymentConsentId`.
+ */
 interface PaymentSuccessResult {
   status: 'success';
   paymentConsentId?: string;
 }
 
+/**
+ * The payment has been submitted but its final outcome is not yet known.
+ * The merchant should poll the payment intent or wait for a webhook to confirm the result.
+ */
 interface PaymentInProgressResult {
   status: 'inProgress';
 }
 
+/**
+ * The customer cancelled the payment flow before it completed.
+ */
 interface PaymentCancelledResult {
   status: 'cancelled';
 }
 
+/**
+ * The outcome of a payment flow. Discriminated by `status`:
+ * `'success'`, `'inProgress'`, or `'cancelled'`.
+ *
+ * Errors are not represented here — they are surfaced by the returned promise rejecting.
+ */
 export type PaymentResult =
   | PaymentSuccessResult
   | PaymentInProgressResult

--- a/src/types/PaymentSession.ts
+++ b/src/types/PaymentSession.ts
@@ -18,6 +18,9 @@ interface BaseSession {
   clientSecret: string;
 }
 
+/**
+ * A single (non-recurring) payment against a payment intent.
+ */
 export interface OneOffSession extends BaseSession {
   type: 'OneOff';
   paymentIntentId: string;
@@ -25,6 +28,10 @@ export interface OneOffSession extends BaseSession {
   hidePaymentConsents?: boolean;
 }
 
+/**
+ * A session that sets up a payment consent for future recurring charges
+ * without charging the customer right now.
+ */
 export interface RecurringSession extends BaseSession {
   type: 'Recurring';
   customerId: string;
@@ -32,6 +39,10 @@ export interface RecurringSession extends BaseSession {
   merchantTriggerReason: MerchantTriggerReason;
 }
 
+/**
+ * A session that charges a payment intent now and sets up a payment consent
+ * for future recurring charges in a single step.
+ */
 export interface RecurringWithIntentSession extends BaseSession {
   type: 'RecurringWithIntent';
   customerId: string;
@@ -41,6 +52,16 @@ export interface RecurringWithIntentSession extends BaseSession {
   merchantTriggerReason: MerchantTriggerReason;
 }
 
+/**
+ * The configuration object passed to every payment flow function. It bundles the
+ * authentication (`clientSecret`), amount and currency, customer details, and
+ * optional wallet configuration into a single value.
+ *
+ * Pick a variant based on what the merchant wants to do:
+ * - {@link OneOffSession} — charge the customer once.
+ * - {@link RecurringSession} — save a payment method for future recurring charges, without charging now.
+ * - {@link RecurringWithIntentSession} — charge now AND save the payment method for future recurring charges.
+ */
 export type PaymentSession =
   | OneOffSession
   | RecurringSession

--- a/src/types/PaymentSheetConfiguration.ts
+++ b/src/types/PaymentSheetConfiguration.ts
@@ -1,5 +1,14 @@
+/**
+ * How payment methods are arranged on the payment sheet.
+ *
+ * - `'tab'` — payment methods shown as horizontally-scrollable tabs.
+ * - `'accordion'` — payment methods stacked vertically, expanding on tap.
+ */
 export type PaymentLayout = 'tab' | 'accordion';
 
+/**
+ * Optional UI configuration for the payment sheet shown by {@link presentEntirePaymentFlow}.
+ */
 export interface PaymentSheetConfiguration {
   layout: PaymentLayout;
 }

--- a/src/types/Shipping.ts
+++ b/src/types/Shipping.ts
@@ -1,3 +1,7 @@
+/**
+ * Customer shipping (and billing, when reused via `PaymentMethod.billing`) details
+ * pre-filled into the payment sheet.
+ */
 export interface Shipping {
   firstName?: string;
   lastName?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,5 @@ export * from './Shipping';
 export * from './ApplePayOptions';
 export * from './GooglePayOptions';
 export * from './PaymentSheetConfiguration';
+export * from './Card';
+export * from './PaymentResult';


### PR DESCRIPTION
1. Add TSDoc comments to all public API.
2. Export Card and PaymentResult from [src/types/index.ts](vscode-webview://1n6pbo3ioi0jo3d0ikcq479k5pg2p4t7konfmdf8jmr5u6kof9h4/src/types/index.ts) so consumers can `import type { Card, PaymentResult }` from the package
3. enable/disable local log filed by `saveLogToLocal` for iOS