### PR TITLE
ci: use commit hash for github actions

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate API docs
         run: yarn docs
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs
 
@@ -38,4 +38,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128


### PR DESCRIPTION
This PR use commit hash instead of tag for the github action - required by security team
The doc generation/deployment has been validated on my forked repo:
doc:  https://weiping-awx.github.io/airwallex-payment-react-native/
workflow run: https://github.com/weiping-awx/airwallex-payment-react-native/actions/runs/27611431529